### PR TITLE
Add missing php7-curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk -U --no-cache add \
     nodejs-npm \
     php7 \
     php7-ctype \
+    php7-curl \
     php7-dom \
     php7-iconv \
     php7-json \


### PR DESCRIPTION
`ext-curl` is needed by Sentry:
```
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sentry/sentry 1.7.0 requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - sentry/sentry 1.7.0 requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - Installation request for sentry/sentry 1.7.0 -> satisfiable by sentry/sentry[1.7.0].
```