### PR TITLE
Add openssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk -U --no-cache add \
     make \
     nasm \
     nodejs-npm \
+    openssh \
     php7 \
     php7-ctype \
     php7-curl \


### PR DESCRIPTION
This is required if you want to be able to do stuff like submodule checkouts from private repo's.