### PR TITLE
Add php7-pear and g++ compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apk -U --no-cache add \
     php7 \
     php7-ctype \
     php7-curl \
+    php7-dev \
     php7-dom \
     php7-fileinfo \
     php7-gettext \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk -U --no-cache add \
     build-base \
     curl \
     docker \
+    g++ \
     git \
     libjpeg-turbo \
     libjpeg-turbo-dev \
@@ -35,6 +36,7 @@ RUN apk -U --no-cache add \
     php7-ldap \
     php7-mbstring \
     php7-mcrypt \
+    php7-pear \
     php7-pcntl \
     php7-pdo_mysql \
     php7-pdo_pgsql \


### PR DESCRIPTION
These are needed if you need to install particular PEAR / PECL packages (e.g. gnupg)