### PR TITLE
Set the alpine version back because builds are failing right now

### DIFF
--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.6
 
 MAINTAINER docker@stefan-van-essen.nl
 


### PR DESCRIPTION
For some projects the builds are failing because of the installed packages. Can we reset the version back for now?