### PR TITLE
Install intl extension on the PHP images

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -31,6 +31,7 @@ RUN apk -U --no-cache add \
     php5-gd \
     php5-gmp \
     php5-iconv \
+    php5-intl \
     php5-json \
     php5-ldap \
     php5-mcrypt \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -30,6 +30,7 @@ RUN apk -U --no-cache add \
     php7-gd \
     php7-gmp \
     php7-iconv \
+    php7-intl \
     php7-json \
     php7-ldap \
     php7-mbstring \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -31,6 +31,7 @@ RUN apk -U --no-cache add \
     php7-gd \
     php7-gmp \
     php7-iconv \
+    php7-intl \
     php7-json \
     php7-ldap \
     php7-mbstring \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -35,6 +35,7 @@ RUN apk -U --no-cache add \
     php7-gd@php \
     php7-gmp@php \
     php7-iconv@php \
+    php7-intl@php \
     php7-json@php \
     php7-ldap@php \
     php7-mbstring@php \


### PR DESCRIPTION
### What has been done
- installed php-intl on the 5.6, 7.0, 7.1 and 7.2 images

### How to test
- Check the build, acknowledge that the images are build successfully