### PR TITLE
Fix PHP 7.2 warnings 

### DIFF
--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -37,7 +37,6 @@ RUN apk -U --no-cache add \
     php7-json@php \
     php7-ldap@php \
     php7-mbstring@php \
-    php7-mcrypt@php \
     php7-openssl@php \
     php7-pcntl@php \
     php7-pdo_mysql@php \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -30,7 +30,6 @@ RUN apk -U --no-cache add \
     php7-ctype@php \
     php7-curl@php \
     php7-dom@php \
-    php7-fileinfo@php \
     php7-gettext@php \
     php7-gd@php \
     php7-gmp@php \
@@ -47,13 +46,10 @@ RUN apk -U --no-cache add \
     php7-phar@php \
     php7-redis@php \
     php7-session@php \
-    php7-simplexml@php \
     php7-snmp@php \
-    php7-tokenizer@php \
     php7-xdebug@php \
     php7-xml@php \
     php7-xmlreader@php \
-    php7-xmlwriter@php \
     php7-zip@php \
     php7-zlib@php \
     && ln -s /usr/bin/php7 /usr/bin/php \


### PR DESCRIPTION
Heya,

The current PHP 7.2 builder contains a lot of warnings about missing symbols and wrongfull configuration. Turns out we were installing some depricated or conflicting packages.

An example of the output before:
```
PHP Warning:  PHP Startup: Unable to load dynamic library 'fileinfo.so' (tried: /usr/lib/php7/modules/fileinfo.so (Error relocating /usr/lib/php7/modules/fileinfo.so: vspprintf: symbol not found), /usr/lib/php7/modules/fileinfo.so.so (Error loading shared library /usr/lib/php7/modules/fileinfo.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library 'mcrypt.so' (tried: /usr/lib/php7/modules/mcrypt.so (Error relocating /usr/lib/php7/modules/mcrypt.so: spprintf: symbol not found), /usr/lib/php7/modules/mcrypt.so.so (Error loading shared library /usr/lib/php7/modules/mcrypt.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library 'simplexml.so' (tried: /usr/lib/php7/modules/simplexml.so (Error relocating /usr/lib/php7/modules/simplexml.so: spl_ce_Countable: symbol not found), /usr/lib/php7/modules/simplexml.so.so (Error loading shared library /usr/lib/php7/modules/simplexml.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: tokenizer: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
PHP Warning:  PHP Startup: xmlwriter: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
PHP 7.2.4 (cli) (built: Apr  8 2018 12:52:48) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Xdebug v2.6.0, Copyright (c) 2002-2018, by Derick Rethans
```

An example of the ouput after:
``` 
PHP 7.2.4 (cli) (built: Apr  8 2018 12:52:48) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Xdebug v2.6.0, Copyright (c) 2002-2018, by Derick Rethans
```

### What has been done
- Removed installation of the `fileinfo` extension because it is installed by default
- Removed installation of the `simplexml` extension because it is installed by default
- Removed installation of the `tokenizer` extension because it is installed by default
- Removed installation of the `xmlwriter` extension because it is installed by default
- Removed  installation of the `mcrypt` extension because it [should have been deprecated](https://blog.remirepo.net/post/2015/07/07/About-libmcrypt-and-php-mcrypt).