### PR TITLE
Add required dependencies for the libpng-dev to work properly

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -9,9 +9,11 @@ RUN apk -U --no-cache add \
     autoconf \
     automake \
     build-base \
+    bash \
     curl \
     docker \
     git \
+    g++ \
     libjpeg-turbo \
     libjpeg-turbo-dev \
     libpng \
@@ -46,6 +48,7 @@ RUN apk -U --no-cache add \
     php5-xmlreader \
     php5-zip \
     php5-zlib \
+    zlib-dev \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g yarn \
     && sed -i 's/;zend/zend/g' /etc/php5/conf.d/xdebug.ini

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -9,9 +9,11 @@ RUN apk -U --no-cache add \
     autoconf \
     automake \
     build-base \
+    bash \
     curl \
     docker \
     git \
+    g++ \
     libjpeg-turbo \
     libjpeg-turbo-dev \
     libpng \
@@ -48,6 +50,7 @@ RUN apk -U --no-cache add \
     php7-xmlreader \
     php7-zip \
     php7-zlib \
+    zlib-dev \
     && ln -s /usr/bin/php7 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g yarn \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -9,9 +9,11 @@ RUN apk -U --no-cache add \
     autoconf \
     automake \
     build-base \
+    bash \
     curl \
     docker \
     git \
+    g++ \
     libjpeg-turbo \
     libjpeg-turbo-dev \
     libpng \
@@ -52,6 +54,7 @@ RUN apk -U --no-cache add \
     php7-xmlwriter \
     php7-zip \
     php7-zlib \
+    zlib-dev \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g yarn \
     && sed -i 's/;zend/zend/g' /etc/php7/conf.d/xdebug.ini

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -13,9 +13,11 @@ RUN apk -U --no-cache add \
     autoconf \
     automake \
     build-base \
+    bash \
     curl \
     docker \
     git \
+    g++ \
     libjpeg-turbo \
     libjpeg-turbo-dev \
     libpng \
@@ -52,6 +54,7 @@ RUN apk -U --no-cache add \
     php7-xmlreader@php \
     php7-zip@php \
     php7-zlib@php \
+    zlib-dev \
     && ln -s /usr/bin/php7 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g yarn


### PR DESCRIPTION
### What

There is an issue with building PNG images in the latest alpine repositories, adding a few more dependencies fixes this issue.

This fix is required for image manipulation libraries with for example webpack builds.