### PR TITLE
Use the same extensions for PHP 7.3 as for PHP 7.1 and 7.2

### DIFF
--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -26,19 +26,21 @@ RUN apk -U --no-cache add \
     nodejs \
     nodejs-npm \
     openssh \
-    php \
+    php7 \
     php7-ctype \
     php7-curl \
     php7-dom \
+    php7-fileinfo \
     php7-gettext \
     php7-gd \
     php7-gmp \
     php7-iconv \
+    php7-intl \
     php7-json \
     php7-ldap \
     php7-mbstring \
+    php7-mcrypt \
     php7-openssl \
-    php7-pecl-xdebug \
     php7-pcntl \
     php7-pdo_mysql \
     php7-pdo_pgsql \
@@ -47,9 +49,14 @@ RUN apk -U --no-cache add \
     php7-posix \
     php7-redis \
     php7-session \
+    php7-simplexml \
+    php7-snmp \
     php7-soap \
+    php7-tokenizer \
+    php7-xdebug \
     php7-xml \
     php7-xmlreader \
+    php7-xmlwriter \
     php7-zip \
     php7-zlib \
     zlib-dev \


### PR DESCRIPTION
### What

Install the same extensions for PHP 7.3 as for PHP 7.1 and PHP 7.3

###  Why

Makes it much easier what to expect when upgrading from one version to another