### PR TITLE
Add gnu-libiconv before zlib to prevent unintended partial uninstall of the latter

### DIFF
--- a/Dockerfile-7.4-codecasts
+++ b/Dockerfile-7.4-codecasts
@@ -8,6 +8,11 @@ ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-a
 RUN apk --update add ca-certificates
 RUN echo "https://dl.bintray.com/php-alpine/v3.10/php-7.4" >> /etc/apk/repositories
 
+# Temporary workaround for problems with php7-iconv on Alpine based PHP images
+# See https://github.com/docker-library/php/issues/240 for more info
+RUN apk add gnu-libiconv --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
+ENV LD_PRELOAD='/usr/lib/preloadable_libiconv.so php'
+
 RUN apk -U --no-cache add \
     alpine-sdk \
     autoconf \
@@ -66,7 +71,3 @@ RUN apk -U --no-cache add \
 
 COPY cache-tool.sh /usr/local/bin/cache-tool
 
-# Temporary workaround for problems with php7-iconv on Alpine based PHP images
-# See https://github.com/docker-library/php/issues/240 for more info
-RUN apk add gnu-libiconv --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
-ENV LD_PRELOAD='/usr/lib/preloadable_libiconv.so php'


### PR DESCRIPTION
### Summary
**What did I do:** try to use the zlib extension in the existenz/builder:7.4-codecasts image
**What did I expect:** the zlib extension is useable
**What did I see:** the zlib extension is not useable

### Background
The current 7.4-codecasts version of the builder does not have the zlib extension, even though it is installed via apk. The reason for this is that the "workaround for problems with php7-iconv on Alpine" command in the Dockerfile has the side effect of removing the zlib extension in an odd way: it is removed from PHP but apk still thinks it is installed.

## Solution
The problem does not occur if iconv is installed first, so I reversed the order.

## Reproduction/how to test
Run the following commands, and read the comments:
```bash
> docker run --rm -it existenz/builder:7.4-codecasts /bin/sh -c "php -m" | grep zlib
> # see that the extension was not found
> docker build --file Dockerfile-7.4-codecasts -t builder_with_zlib:local .
Sending build context to Docker daemon  159.7kB
Step 1/10 : FROM alpine:3.10
# more output was skipped
Successfully tagged builder_with_zlib:local
> docker run --rm -it builder_with_zlib:local /bin/sh -c "php -m" | grep zlib
zlib
> # see that the extension was found
```

## Notes
I did not test if this had any side-effects, so please review this with a critical eye :-) 
