### PR TITLE
Add buildah and podman for rootless, daemonless, actual multistage builds

### DIFF
--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -28,6 +28,7 @@ COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
 RUN apk -U --no-cache add \
     bash \
+    buildah \
     curl \
     docker \
     git \
@@ -77,6 +78,7 @@ RUN apk -U --no-cache add \
     php7-xmlwriter \
     php7-zip \
     php7-zlib \
+    podman \
     zlib-dev \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g --unsafe-perm yarn \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -26,9 +26,12 @@ ENV LD_PRELOAD='/usr/lib/preloadable_libiconv.so php'
 ENV MUSL_LOCPATH /usr/share/i18n/locales/musl
 COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
+RUN apk -U --no-cache add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+    buildah \
+    podman
+
 RUN apk -U --no-cache add \
     bash \
-    buildah \
     curl \
     docker \
     git \
@@ -78,7 +81,6 @@ RUN apk -U --no-cache add \
     php7-xmlwriter \
     php7-zip \
     php7-zlib \
-    podman \
     zlib-dev \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && npm install -g --unsafe-perm yarn \

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -28,6 +28,7 @@ COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
 RUN apk -U --no-cache add \
     bash \
+    buildah \
     curl \
     cmake \
     docker \
@@ -78,6 +79,7 @@ RUN apk -U --no-cache add \
     php8-xmlwriter \
     php8-zip \
     php8-zlib \
+    podman \
     zlib-dev \
     && ln -s /usr/bin/php8 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -26,9 +26,12 @@ ENV LD_PRELOAD='/usr/lib/preloadable_libiconv.so php'
 ENV MUSL_LOCPATH /usr/share/i18n/locales/musl
 COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
+RUN apk -U --no-cache add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+    buildah \
+    podman
+
 RUN apk -U --no-cache add \
     bash \
-    buildah \
     curl \
     cmake \
     docker \
@@ -79,7 +82,6 @@ RUN apk -U --no-cache add \
     php8-xmlwriter \
     php8-zip \
     php8-zlib \
-    podman \
     zlib-dev \
     && ln -s /usr/bin/php8 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/Dockerfile-8.1
+++ b/Dockerfile-8.1
@@ -28,9 +28,12 @@ COPY --from=locales /usr/lib/preloadable_libiconv.so /usr/lib/preloadable_libico
 ENV MUSL_LOCPATH /usr/share/i18n/locales/musl
 COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
+RUN apk -U --no-cache add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+    buildah \
+    podman \
+
 RUN apk -U --no-cache add \
     bash \
-    buildah \
     curl \
     docker \
     git \
@@ -78,7 +81,6 @@ RUN apk -U --no-cache add \
     php81-xmlwriter \
     php81-zip \
     php81-zlib \
-    podman \
     zlib-dev \
     && ln -s /usr/bin/php81 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/Dockerfile-8.1
+++ b/Dockerfile-8.1
@@ -30,6 +30,7 @@ COPY --from=locales /usr/share/i18n/locales/musl /usr/share/i18n/locales/musl
 
 RUN apk -U --no-cache add \
     bash \
+    buildah \
     curl \
     docker \
     git \
@@ -77,6 +78,7 @@ RUN apk -U --no-cache add \
     php81-xmlwriter \
     php81-zip \
     php81-zlib \
+    podman \
     zlib-dev \
     && ln -s /usr/bin/php81 /usr/bin/php \
     && curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \


### PR DESCRIPTION
Reasoning? See [this pipeline](https://gitlab.enrise.com/jvoverbeeke/buildah-test/-/pipelines/230336/builds) in [this repo](https://gitlab.enrise.com/jvoverbeeke/buildah-test/-/tree/master) :-D.

# Note
I had not forseen that adding buildah and podman would result in installation of 54 packages or random failure of the image build :-( . I'm out of time now, so I'll have to continue this later.